### PR TITLE
Load the jquery.cycle library from any folder accepted by Drupal 8.

### DIFF
--- a/field_slideshow.install
+++ b/field_slideshow.install
@@ -16,7 +16,11 @@ function field_slideshow_requirements($phase) {
 	if ($phase == 'runtime') {
 		//$path = libraries_get_path('jquery.cycle');
     $path = '';
-    if ($path == '') $path = DRUPAL_ROOT . '/libraries/jquery.cycle';
+    if ($path == ''){ 
+      $path = DRUPAL_ROOT . '/libraries/jquery.cycle';
+      if(\Drupal::moduleHandler()->moduleExists('libraries'))
+        $path = DRUPAL_ROOT . '/' . libraries_get_path('jquery.cycle');
+    }
     if (file_exists($path . '/jquery.cycle.all.min.js') || file_exists($path . '/jquery.cycle.all.js')) {
       $requirements['field_slideshow_cycle_plugin'] = array(
         'title'     => t('JQuery Cycle plugin'),

--- a/field_slideshow.module
+++ b/field_slideshow.module
@@ -78,10 +78,10 @@ function template_preprocess_field_slideshow(&$variables) {
     $variables['#attached']['drupalSettings']['field_slideshow'] = array(
       'field-slideshow-' . $variables['slideshow_id'] => $js_variables,
     );
-    if (file_exists($libraries_path . '/jquery.cycle/jquery.cycle.all.min.js')) {
+    if (file_exists($libraries_path . '/jquery.cycle/jquery.cycle.all.min.js') || file_exists(DRUPAL_ROOT . '/' . libraries_get_path('jquery.cycle') . '/jquery.cycle.all.min.js')) {
       $variables['#attached']['library'][] = 'field_slideshow/field_slideshow.jquery.cycle.min';
     }
-    elseif (file_exists($libraries_path . '/jquery.cycle/jquery.cycle.all.js')) {
+    elseif (file_exists($libraries_path . '/jquery.cycle/jquery.cycle.all.js') || file_exists(DRUPAL_ROOT . '/' . libraries_get_path('jquery.cycle') . '/jquery.cycle.all.js')) {
       $variables['#attached']['library'][] = 'field_slideshow/field_slideshow.jquery.cycle.all';
     }
 
@@ -296,4 +296,16 @@ function field_slideshow_colorbox_settings_alter(&$settings, &$style) {
   }
 
   //slideshow=true&slideshowAuto=true&slideshowSpeed=4000&speed=350&transition=elastic
+}
+
+/**
+ * Implements hook_library_info_alter().
+ */
+function field_slideshow_library_info_alter(&$libraries, $extension) {
+  if ($extension == 'field_slideshow' && \Drupal::moduleHandler()->moduleExists('libraries')) {
+    if(file_exists(DRUPAL_ROOT . '/' . libraries_get_path('jquery.cycle') . '/jquery.cycle.all.min.js'))
+      $libraries['field_slideshow.jquery.cycle.min']['js'] = ['/'.libraries_get_path('jquery.cycle') . '/jquery.cycle.all.min.js' => []];
+    if(file_exists(DRUPAL_ROOT . '/' . libraries_get_path('jquery.cycle') . '/jquery.cycle.all.js'))
+      $libraries['field_slideshow.jquery.cycle.all']['js'] = ['/'.libraries_get_path('jquery.cycle') . '/jquery.cycle.all.js' => []];
+  }
 }

--- a/src/Plugin/Field/FieldFormatter/FieldCollectionSlideshow.php
+++ b/src/Plugin/Field/FieldFormatter/FieldCollectionSlideshow.php
@@ -452,7 +452,7 @@ class FieldCollectionSlideshow extends FieldCollectionItemsFormatter {
 
     // Check plugins
     if (\Drupal::moduleHandler()->moduleExists('libraries')) {
-      if (!file_exists(DRUPAL_ROOT . '/libraries/jquery.cycle/jquery.cycle.all.min.js') && !file_exists(DRUPAL_ROOT . '/libraries/jquery.cycle/jquery.cycle.all.js')) {
+      if (!file_exists(DRUPAL_ROOT . '/' . libraries_get_path('jquery.cycle'). '/jquery.cycle.all.min.js') && !file_exists(DRUPAL_ROOT . '/' . libraries_get_path('jquery.cycle'). '/jquery.cycle.all.js')) {
         $url = Url::fromRoute('system.status');
         drupal_set_message(t('JQuery Cycle must be installed in order to run the slideshow. Please go to !page for instructions.', array('!page' => \Drupal::l(t('Status Report'), $url))), 'warning', FALSE);
       }

--- a/src/Plugin/Field/FieldFormatter/FieldSlideshow.php
+++ b/src/Plugin/Field/FieldFormatter/FieldSlideshow.php
@@ -383,7 +383,7 @@ class FieldSlideshow extends ImageFormatter {
     $files = $this->getEntitiesToView($items, $langcode);
     // Check plugins
     if (\Drupal::moduleHandler()->moduleExists('libraries')) {
-      if (!file_exists(DRUPAL_ROOT . '/libraries/jquery.cycle/jquery.cycle.all.min.js') && !file_exists(DRUPAL_ROOT . '/libraries/jquery.cycle/jquery.cycle.all.js')) {
+      if (!file_exists(DRUPAL_ROOT . '/' . libraries_get_path('jquery.cycle'). '/jquery.cycle.all.min.js') && !file_exists(DRUPAL_ROOT . '/' . libraries_get_path('jquery.cycle'). '/jquery.cycle.all.js')) {
         $url = Url::fromRoute('system.status');
         drupal_set_message(t('JQuery Cycle must be installed in order to run the slideshow. Please go to !page for instructions.', array('!page' => \Drupal::l(t('Status Report'), $url))), 'warning', FALSE);
       }


### PR DESCRIPTION
Currently the module will only work if the library is placed inside the root/library folder which is quite limiting.

Tested when the regular library (not the minified one) is downloaded by drush inside a profile/libraries folder.
